### PR TITLE
Revert link to point to Swagger UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       <h1 class="project-name">MaaS-API</h1>
       <h2 class="project-tagline">Powering Mobility as a Service</h2>
       <a href="https://github.com/maasglobal/maas-tsp-reference/" class="btn">View on GitHub</a>
-      <a href="https://github.com/maasglobal/maas-tsp-reference/tree/master/schemas" class="btn">API Documentation</a>
+      <a href="https://maasglobal.github.io/maas-tsp-api/" class="btn">API Documentation</a>
     </section>
 
     <section class="main-content">


### PR DESCRIPTION
Closes #1 

The documentation should be presented in a developer-friendly format. I understand that the reference schemas are probably better maintained, but think we should rather work to improve the Swatter documents to match the JSON schemas.

# Changes
- Revert link to show interactive documentation